### PR TITLE
Fix ref callback typing error on achievements timeline

### DIFF
--- a/src/app/achievements/page.tsx
+++ b/src/app/achievements/page.tsx
@@ -252,7 +252,9 @@ const AchievementsPage: React.FC = () => {
             {years.map((year, index) => (
               <div
                 key={year}
-                ref={(el) => (yearRefs.current[year] = el)}
+                ref={(el) => {
+                  yearRefs.current[year] = el;
+                }}
                 className={`${styles.timelineItem} ${selectedYear === year ? styles.active : ''}`}
                 onClick={() => scrollToYear(year)}
               >


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript/React build-time error caused by a callback `ref` expression that returned the assigned element instead of `void`, which made the component fail to compile.

### Description
- Replace `ref={(el) => (yearRefs.current[year] = el)}` with a block callback `ref={(el) => { yearRefs.current[year] = el; }}` in `src/app/achievements/page.tsx` so the ref callback returns `void` and satisfies `Ref<HTMLDivElement>` typing.

### Testing
- Ran `bun run build` (the original ref typing error is resolved; build now fails later due to an external Google Fonts fetch error from `next/font`) and ran `bunx tsc --noEmit` which reported unrelated pre-existing TypeScript errors in other parts of the app (e.g., tetris files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd9e527b8832b85c73f724eee06b4)